### PR TITLE
Update ip17mon.go

### DIFF
--- a/ip17mon.go
+++ b/ip17mon.go
@@ -86,7 +86,7 @@ func (loc *Locator) Find(ipstr string) (info *LocationInfo, err error) {
 		err = ErrInvalidIp
 		return
 	}
-	info = loc.FindByUint(binary.BigEndian.Uint32([]byte(ip))
+	info = loc.FindByUint(binary.BigEndian.Uint32([]byte(ip)))
 	return
 }
 

--- a/ip17mon.go
+++ b/ip17mon.go
@@ -81,12 +81,12 @@ type LocationInfo struct {
 // Find locationInfo by ip string
 // It will return err when ipstr is not a valid format
 func (loc *Locator) Find(ipstr string) (info *LocationInfo, err error) {
-	ip := net.ParseIP(ipstr)
+	ip := net.ParseIP(ipstr).To4()
 	if ip == nil {
 		err = ErrInvalidIp
 		return
 	}
-	info = loc.FindByUint(binary.BigEndian.Uint32([]byte(ip.To4())))
+	info = loc.FindByUint(binary.BigEndian.Uint32([]byte(ip))
 	return
 }
 


### PR DESCRIPTION
ipv6 ip string will panic:
index out of range in line 89.
Put the ip.To4() at first will cause this bug.
